### PR TITLE
빌드파일에서 InitPhoton이 실행되지 않는 버그 수정

### DIFF
--- a/Assets/Scripts/Net/PhotonStartup.cs
+++ b/Assets/Scripts/Net/PhotonStartup.cs
@@ -11,7 +11,7 @@ public static class PhotonStartup
     /// <summary>
     /// 최초로 게임이 실행될 때 씬이 로드되기 전 호출됩니다.
     /// </summary>
-    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
     private static void InitPhoton()
     {
         InitGameVersion();


### PR DESCRIPTION
`RuntimeInitializeLoadType.AfterAssembliesLoaded` 를 사용할 경우 빌드파일에서 제대로 실행되지 않는 이슈를 확인하였고 대신 `BeforeSceneLoad`를 사용하여 씬 로드 직전에 메소드를 실행하도록 수정하였습니다.